### PR TITLE
Support for jobs using the cloudbees folder plugins

### DIFF
--- a/plugin/src/main/groovy/nl/ikoodi/gradle/plugin/jenkins/jobdsl/GradleFileJobManagement.groovy
+++ b/plugin/src/main/groovy/nl/ikoodi/gradle/plugin/jenkins/jobdsl/GradleFileJobManagement.groovy
@@ -48,6 +48,9 @@ class GradleFileJobManagement extends FileJobManagement {
 
     private void writeConfig(String jobName, String config) {
         validateUpdateArgs(jobName, config);
-        new File(outputDirectory, jobName + ext).write(config)
+        def jobPathName = new File(outputDirectory, jobName + ext)
+        jobPathName.getParentFile()?.mkdirs()
+
+        jobPathName.write(config)
     }
 }


### PR DESCRIPTION
This patch allows to generate XML of job definitions that are using
the cloudbees' Folder plugin (instead of generating an error):

// will create build/jobDsl/generated/folder_test.xml
folder {
 name 'folder_test'
}

// will create build/jobDsl/generated/folder_test/my_job.xml
job {
 name 'folder_test/my_job'
 ...
}

Signed-off-by: Brice Figureau brice-puppet@daysofwonder.com
