### PR TITLE
added support for supplying bindings map.

### DIFF
--- a/examples/job-with-binding/build.gradle
+++ b/examples/job-with-binding/build.gradle
@@ -1,0 +1,20 @@
+buildscript {
+    repositories {
+        mavenLocal()
+        jcenter()
+    }
+
+    dependencies {
+        classpath 'nl.ikoodi.gradle.plugin:gradle-jenkins-jobdsl:0.1.6'
+    }
+}
+
+apply plugin: 'base' // not needed for plugin, but provides the 'clean' task
+apply plugin: 'jenkins-jobdsl'
+
+jenkinsJobDsl {
+    jobConfigs {
+        from file('project.dsl.groovy')
+    }
+    binding = ['NAME': project.name]
+}

--- a/examples/job-with-binding/project.dsl.groovy
+++ b/examples/job-with-binding/project.dsl.groovy
@@ -1,0 +1,4 @@
+job {
+    name "${NAME}"
+    description 'Single job example'
+}

--- a/plugin/src/main/groovy/nl/ikoodi/gradle/plugin/jenkins/jobdsl/JenkinsJobDslPluginExtension.groovy
+++ b/plugin/src/main/groovy/nl/ikoodi/gradle/plugin/jenkins/jobdsl/JenkinsJobDslPluginExtension.groovy
@@ -23,8 +23,10 @@ class JenkinsJobDslPluginExtension {
     public static final String DEFAULT_DSL_FILE_PATTERN = '**/*.dsl.groovy'
     private final Project project
     private String baseOutputPath = new File(project.buildDir, 'jobDsl').absolutePath
+
     final CopySpec jobConfigs
     final CopySpec classpath
+    Map binding = [:]
     String dslFilePattern = DEFAULT_DSL_FILE_PATTERN
     String workspaceBuildPath = new File(baseOutputPath, 'workspace').absolutePath
     String generatedOutputPath = new File(baseOutputPath, 'generated').absolutePath

--- a/plugin/src/main/groovy/nl/ikoodi/gradle/plugin/jenkins/jobdsl/tasks/GenerateConfigsTask.groovy
+++ b/plugin/src/main/groovy/nl/ikoodi/gradle/plugin/jenkins/jobdsl/tasks/GenerateConfigsTask.groovy
@@ -73,6 +73,13 @@ class GenerateConfigsTask extends DefaultTask {
                 generatedFilesOutputDirectory,
                 project.projectDir
         );
+
+        Map binding = getExtension().binding
+
+        if (binding) {
+            jm.parameters.putAll(binding)
+        }
+
         scripts.each { File scriptFile ->
             processDslScript(jm, buildWorkspaceOutputDirectory, scriptFile)
         }


### PR DESCRIPTION
This mimics the behavior when jobdsl script is run as buildstep within jenkins and you can have access to the original job's parameters.