### PR TITLE
added getConfigFileId method to GradleFileJobManagement

### DIFF
--- a/plugin/src/main/groovy/nl/ikoodi/gradle/plugin/jenkins/jobdsl/GradleFileJobManagement.groovy
+++ b/plugin/src/main/groovy/nl/ikoodi/gradle/plugin/jenkins/jobdsl/GradleFileJobManagement.groovy
@@ -18,6 +18,7 @@ package nl.ikoodi.gradle.plugin.jenkins.jobdsl
 import javaposse.jobdsl.dsl.ConfigurationMissingException
 import javaposse.jobdsl.dsl.FileJobManagement
 import javaposse.jobdsl.dsl.NameNotProvidedException
+import javaposse.jobdsl.dsl.ConfigFileType
 
 class GradleFileJobManagement extends FileJobManagement {
     File outputDirectory
@@ -49,6 +50,11 @@ class GradleFileJobManagement extends FileJobManagement {
     @Override
     String getCredentialsId(String credentialsDescription) {
         return credentialsDescription
+    }
+
+    @Override
+    String getConfigFileId(ConfigFileType type, String name) {
+        return name
     }
 
     @Override


### PR DESCRIPTION
I need this because some of the jobdsl script that I test through gradle first before running in jenkins rely on this.    Thanks.